### PR TITLE
Add GeoInfer to AI Reverse Image Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@
  <p>AI reverse image search.</p>
 <li><a href="https://geospy.web.app/">Geospy</a></li>
  <p>Geospy will try to locate where an image was taken using AI.</p>
+<li><a href="https://geoinfer.com/">GeoInfer</a></li>
+ <p>Image geolocation tool that identifies where a photo was taken using AI, no EXIF data required.</p>
 <li><a href="https://lenso.ai/en">Lenso</a></li>
   <p>AI Reverse Image Search</p>
 <li><a href="https://huggingface.co/NemesisAlm">NemesisAlm</a></li>


### PR DESCRIPTION
## Summary

- Adds [GeoInfer](https://geoinfer.com/) to the AI Reverse Image Search section
- GeoInfer is an image geolocation tool that uses AI to identify where a photo was taken, no EXIF data required
- Entry follows the existing format and is inserted in alphabetical order between Geospy and Lenso

## Test plan

- [ ] Verify the new entry appears in the AI Reverse Image Search section
- [ ] Verify the link to https://geoinfer.com/ is correct
- [ ] Verify the entry is in alphabetical order